### PR TITLE
added altair 4.0

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,3 +4,4 @@ ta==0.10.1
 yfinance==0.1.72
 watchdog==2.1.9
 protobuf==3.19.0
+altair==4.0


### PR DESCRIPTION
When I ran the dockerfile, I had an error 

  [ModuleNotFoundError: No module named ‘altair.vegalite.v4’](https://discuss.streamlit.io/t/modulenotfounderror-no-module-named-altair-vegalite-v4/42921)

I fixed it, by adding 'altair==4.0’ as part of the packages in the req.txt. 